### PR TITLE
Add initial Flutter prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# codextest
+# Mental Health Support App
+
+This Flutter project is a simple prototype based on the provided requirements for a mental health support application. It demonstrates:
+
+- Email based sign up / login using Firebase Authentication
+- Logging of daily mood to Firestore
+- Basic navigation between login, home and mood logging screens
+
+This code is not production ready but serves as a starting point for further development.
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'screens/login_screen.dart';
+import 'screens/home_screen.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Mental Health App',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const LoginScreen(),
+        '/home': (context) => const HomeScreen(),
+      },
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'mood_log_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+        actions: [
+          IconButton(
+            onPressed: () async {
+              await FirebaseAuth.instance.signOut();
+              if (context.mounted) {
+                Navigator.pushReplacementNamed(context, '/');
+              }
+            },
+            icon: const Icon(Icons.logout),
+          )
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MoodLogScreen()),
+                );
+              },
+              child: const Text('Record Today\'s Mood'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({Key? key}) : super(key: key);
+
+  @override
+  _LoginScreenState createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _login() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: _emailController.text,
+        password: _passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.pushReplacementNamed(context, '/home');
+    } on FirebaseAuthException catch (e) {
+      setState(() {
+        _error = e.message;
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _signup() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: _emailController.text,
+        password: _passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.pushReplacementNamed(context, '/home');
+    } on FirebaseAuthException catch (e) {
+      setState(() {
+        _error = e.message;
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            if (_error != null) ...[
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.red),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (_loading)
+              const CircularProgressIndicator()
+            else
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  ElevatedButton(
+                    onPressed: _login,
+                    child: const Text('Login'),
+                  ),
+                  ElevatedButton(
+                    onPressed: _signup,
+                    child: const Text('Sign Up'),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/mood_log_screen.dart
+++ b/lib/screens/mood_log_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class MoodLogScreen extends StatefulWidget {
+  const MoodLogScreen({Key? key}) : super(key: key);
+
+  @override
+  _MoodLogScreenState createState() => _MoodLogScreenState();
+}
+
+class _MoodLogScreenState extends State<MoodLogScreen> {
+  int _mood = 3; // 1-5
+  final TextEditingController _noteController = TextEditingController();
+  bool _saving = false;
+
+  Future<void> _save() async {
+    setState(() {
+      _saving = true;
+    });
+    await FirebaseFirestore.instance.collection('mood_logs').add({
+      'mood': _mood,
+      'note': _noteController.text,
+      'timestamp': Timestamp.now(),
+    });
+    setState(() {
+      _saving = false;
+    });
+    if (!mounted) return;
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mood Log')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Text('How are you feeling?'),
+            Slider(
+              value: _mood.toDouble(),
+              onChanged: (v) => setState(() => _mood = v.round()),
+              min: 1,
+              max: 5,
+              divisions: 4,
+              label: _mood.toString(),
+            ),
+            TextField(
+              controller: _noteController,
+              decoration: const InputDecoration(labelText: 'Notes'),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 16),
+            _saving
+                ? const CircularProgressIndicator()
+                : ElevatedButton(
+                    onPressed: _save,
+                    child: const Text('Save'),
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/mood_service.dart
+++ b/lib/services/mood_service.dart
@@ -1,0 +1,10 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class MoodService {
+  final CollectionReference _collection =
+      FirebaseFirestore.instance.collection('mood_logs');
+
+  Stream<QuerySnapshot> getMoodLogs() {
+    return _collection.orderBy('timestamp', descending: true).snapshots();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,14 @@
+name: mental_health_app
+version: 0.1.0
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: ^2.24.0
+  firebase_auth: ^4.10.0
+  cloud_firestore: ^4.9.3
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize Flutter project skeleton
- add login screen, home screen and mood logging
- set up Firebase dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d0b02a99c8321aa7747cad2b8a03d